### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cdenihan/UMD-UROC-ROS2-Python-Package/security/code-scanning/1](https://github.com/cdenihan/UMD-UROC-ROS2-Python-Package/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Since the workflow only performs linting operations, the `contents: read` permission is sufficient. This ensures that the `GITHUB_TOKEN` has the least privilege required to complete the task.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
